### PR TITLE
Fix create stream parameters

### DIFF
--- a/src/main/java/com/mindsdb/kafka/connect/client/MindsDBClientConfig.java
+++ b/src/main/java/com/mindsdb/kafka/connect/client/MindsDBClientConfig.java
@@ -58,7 +58,7 @@ public class MindsDBClientConfig {
         parameters.put("stream_in", config.getTopics());
         parameters.put("stream_out", config.getForecastTopic());
         parameters.put("stream_anomaly", config.getAnomalyTopic());
-        parameters.put("integration_name", config.getApiName());
+        parameters.put("integration", config.getApiName());
         parameters.put("type", config.getPredictorType());
 
         return Collections.singletonMap("params", parameters);

--- a/src/test/java/com/mindsdb/kafka/connect/client/MindsDBClientConfigTest.java
+++ b/src/test/java/com/mindsdb/kafka/connect/client/MindsDBClientConfigTest.java
@@ -124,7 +124,7 @@ class MindsDBClientConfigTest {
                         "stream_in", "testTopic",
                         "stream_out", "exitTopic",
                         "stream_anomaly", "anomalyTopic",
-                        "integration_name", "testApi",
+                        "integration", "testApi",
                         "type", "testType"
                 ),
                 result


### PR DESCRIPTION
since MindsDB api has been changed a little, rename 'integration_name' parameter to 'integration'